### PR TITLE
change base image to elixir and then install ROS

### DIFF
--- a/Dockerfile.dashing-ex1.10.4-otp23.3.4
+++ b/Dockerfile.dashing-ex1.10.4-otp23.3.4
@@ -1,0 +1,59 @@
+### FIXME according to branch/tag
+# base image
+FROM hexpm/elixir:1.10.4-erlang-23.3.4-ubuntu-bionic-20210325
+# Set Ubuntu Codename
+ENV UBUNTU_CODENAME bionic
+# Set ROS_DISTRO environment
+ENV ROS_DISTRO dashing
+
+# force error about debconf
+ENV DEBIAN_FRONTEND noninteractive
+
+# update sources list
+RUN apt-get clean
+RUN apt-get update
+
+# install additonal packages
+RUN apt-get install -y git sudo build-essential
+
+# install AStyle to format C code (NIFs)
+RUN apt-get install -y astyle
+
+### install ROS START
+### https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+
+# Set locale
+RUN apt update && apt -y install locales
+RUN locale-gen en_US en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN export LANG=en_US.UTF-8
+
+# Setup Sources
+RUN apt update && apt install -y curl gnupg2 lsb-release
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Install ROS 2 packages
+RUN apt update
+RUN apt install -y ros-${ROS_DISTRO}-ros-base
+
+# Install ROS 2 packages
+RUN apt install -y python3-colcon-common-extensions
+
+# Setup ROS environment in shell
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> ~/.bashrc
+
+### install ROS END
+
+# cleanup
+RUN apt-get -qy autoremove
+
+# install hex and rebar
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+# check version
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && env | grep ROS
+RUN mix hex.info
+

--- a/Dockerfile.dashing-ex1.11.4-otp23.3.4
+++ b/Dockerfile.dashing-ex1.11.4-otp23.3.4
@@ -1,0 +1,59 @@
+### FIXME according to branch/tag
+# base image
+FROM hexpm/elixir:1.11.4-erlang-23.3.4-ubuntu-bionic-20210325
+# Set Ubuntu Codename
+ENV UBUNTU_CODENAME bionic
+# Set ROS_DISTRO environment
+ENV ROS_DISTRO dashing
+
+# force error about debconf
+ENV DEBIAN_FRONTEND noninteractive
+
+# update sources list
+RUN apt-get clean
+RUN apt-get update
+
+# install additonal packages
+RUN apt-get install -y git sudo build-essential
+
+# install AStyle to format C code (NIFs)
+RUN apt-get install -y astyle
+
+### install ROS START
+### https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+
+# Set locale
+RUN apt update && apt -y install locales
+RUN locale-gen en_US en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN export LANG=en_US.UTF-8
+
+# Setup Sources
+RUN apt update && apt install -y curl gnupg2 lsb-release
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Install ROS 2 packages
+RUN apt update
+RUN apt install -y ros-${ROS_DISTRO}-ros-base
+
+# Install ROS 2 packages
+RUN apt install -y python3-colcon-common-extensions
+
+# Setup ROS environment in shell
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> ~/.bashrc
+
+### install ROS END
+
+# cleanup
+RUN apt-get -qy autoremove
+
+# install hex and rebar
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+# check version
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && env | grep ROS
+RUN mix hex.info
+

--- a/Dockerfile.dashing-ex1.12.3-otp24.1.5
+++ b/Dockerfile.dashing-ex1.12.3-otp24.1.5
@@ -1,0 +1,59 @@
+### FIXME according to branch/tag
+# base image
+FROM hexpm/elixir:1.12.3-erlang-24.1.5-ubuntu-bionic-20210325
+# Set Ubuntu Codename
+ENV UBUNTU_CODENAME bionic
+# Set ROS_DISTRO environment
+ENV ROS_DISTRO dashing
+
+# force error about debconf
+ENV DEBIAN_FRONTEND noninteractive
+
+# update sources list
+RUN apt-get clean
+RUN apt-get update
+
+# install additonal packages
+RUN apt-get install -y git sudo build-essential
+
+# install AStyle to format C code (NIFs)
+RUN apt-get install -y astyle
+
+### install ROS START
+### https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+
+# Set locale
+RUN apt update && apt -y install locales
+RUN locale-gen en_US en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN export LANG=en_US.UTF-8
+
+# Setup Sources
+RUN apt update && apt install -y curl gnupg2 lsb-release
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Install ROS 2 packages
+RUN apt update
+RUN apt install -y ros-${ROS_DISTRO}-ros-base
+
+# Install ROS 2 packages
+RUN apt install -y python3-colcon-common-extensions
+
+# Setup ROS environment in shell
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> ~/.bashrc
+
+### install ROS END
+
+# cleanup
+RUN apt-get -qy autoremove
+
+# install hex and rebar
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+# check version
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && env | grep ROS
+RUN mix hex.info
+

--- a/Dockerfile.dashing-ex1.9.4-otp22.3.4.18
+++ b/Dockerfile.dashing-ex1.9.4-otp22.3.4.18
@@ -1,0 +1,59 @@
+### FIXME according to branch/tag
+# base image
+FROM hexpm/elixir:1.9.4-erlang-22.3.4.18-ubuntu-bionic-20210325
+# Set Ubuntu Codename
+ENV UBUNTU_CODENAME bionic
+# Set ROS_DISTRO environment
+ENV ROS_DISTRO dashing
+
+# force error about debconf
+ENV DEBIAN_FRONTEND noninteractive
+
+# update sources list
+RUN apt-get clean
+RUN apt-get update
+
+# install additonal packages
+RUN apt-get install -y git sudo build-essential
+
+# install AStyle to format C code (NIFs)
+RUN apt-get install -y astyle
+
+### install ROS START
+### https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+
+# Set locale
+RUN apt update && apt -y install locales
+RUN locale-gen en_US en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN export LANG=en_US.UTF-8
+
+# Setup Sources
+RUN apt update && apt install -y curl gnupg2 lsb-release
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Install ROS 2 packages
+RUN apt update
+RUN apt install -y ros-${ROS_DISTRO}-ros-base
+
+# Install ROS 2 packages
+RUN apt install -y python3-colcon-common-extensions
+
+# Setup ROS environment in shell
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> ~/.bashrc
+
+### install ROS END
+
+# cleanup
+RUN apt-get -qy autoremove
+
+# install hex and rebar
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+# check version
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && env | grep ROS
+RUN mix hex.info
+

--- a/Dockerfile.foxy-ex1.11.4-otp23.3.4
+++ b/Dockerfile.foxy-ex1.11.4-otp23.3.4
@@ -1,0 +1,59 @@
+### FIXME according to branch/tag
+# base image
+FROM hexpm/elixir:1.11.4-erlang-23.3.4-ubuntu-focal-20210325
+# Set Ubuntu Codename
+ENV UBUNTU_CODENAME focal
+# Set ROS_DISTRO environment
+ENV ROS_DISTRO foxy
+
+# force error about debconf
+ENV DEBIAN_FRONTEND noninteractive
+
+# update sources list
+RUN apt-get clean
+RUN apt-get update
+
+# install additonal packages
+RUN apt-get install -y git sudo build-essential
+
+# install AStyle to format C code (NIFs)
+RUN apt-get install -y astyle
+
+### install ROS START
+### https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+
+# Set locale
+RUN apt update && apt -y install locales
+RUN locale-gen en_US en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN export LANG=en_US.UTF-8
+
+# Setup Sources
+RUN apt update && apt install -y curl gnupg2 lsb-release
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Install ROS 2 packages
+RUN apt update
+RUN apt install -y ros-${ROS_DISTRO}-ros-base
+
+# Install ROS 2 packages
+RUN apt install -y python3-colcon-common-extensions
+
+# Setup ROS environment in shell
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> ~/.bashrc
+
+### install ROS END
+
+# cleanup
+RUN apt-get -qy autoremove
+
+# install hex and rebar
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+# check version
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && env | grep ROS
+RUN mix hex.info
+

--- a/Dockerfile.foxy-ex1.12.3-otp24.1.5
+++ b/Dockerfile.foxy-ex1.12.3-otp24.1.5
@@ -1,0 +1,59 @@
+### FIXME according to branch/tag
+# base image
+FROM hexpm/elixir:1.12.3-erlang-24.1.5-ubuntu-focal-20210325
+# Set Ubuntu Codename
+ENV UBUNTU_CODENAME focal
+# Set ROS_DISTRO environment
+ENV ROS_DISTRO foxy
+
+# force error about debconf
+ENV DEBIAN_FRONTEND noninteractive
+
+# update sources list
+RUN apt-get clean
+RUN apt-get update
+
+# install additonal packages
+RUN apt-get install -y git sudo build-essential
+
+# install AStyle to format C code (NIFs)
+RUN apt-get install -y astyle
+
+### install ROS START
+### https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+
+# Set locale
+RUN apt update && apt -y install locales
+RUN locale-gen en_US en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN export LANG=en_US.UTF-8
+
+# Setup Sources
+RUN apt update && apt install -y curl gnupg2 lsb-release
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Install ROS 2 packages
+RUN apt update
+RUN apt install -y ros-${ROS_DISTRO}-ros-base
+
+# Install ROS 2 packages
+RUN apt install -y python3-colcon-common-extensions
+
+# Setup ROS environment in shell
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> ~/.bashrc
+
+### install ROS END
+
+# cleanup
+RUN apt-get -qy autoremove
+
+# install hex and rebar
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+# check version
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && env | grep ROS
+RUN mix hex.info
+

--- a/Dockerfile.foxy-ex1.13.1-otp24.1.7
+++ b/Dockerfile.foxy-ex1.13.1-otp24.1.7
@@ -1,0 +1,59 @@
+### FIXME according to branch/tag
+# base image
+FROM hexpm/elixir:1.13.1-erlang-24.1.7-ubuntu-focal-20210325
+# Set Ubuntu Codename
+ENV UBUNTU_CODENAME focal
+# Set ROS_DISTRO environment
+ENV ROS_DISTRO foxy
+
+# force error about debconf
+ENV DEBIAN_FRONTEND noninteractive
+
+# update sources list
+RUN apt-get clean
+RUN apt-get update
+
+# install additonal packages
+RUN apt-get install -y git sudo build-essential
+
+# install AStyle to format C code (NIFs)
+RUN apt-get install -y astyle
+
+### install ROS START
+### https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+
+# Set locale
+RUN apt update && apt -y install locales
+RUN locale-gen en_US en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN export LANG=en_US.UTF-8
+
+# Setup Sources
+RUN apt update && apt install -y curl gnupg2 lsb-release
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Install ROS 2 packages
+RUN apt update
+RUN apt install -y ros-${ROS_DISTRO}-ros-base
+
+# Install ROS 2 packages
+RUN apt install -y python3-colcon-common-extensions
+
+# Setup ROS environment in shell
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> ~/.bashrc
+
+### install ROS END
+
+# cleanup
+RUN apt-get -qy autoremove
+
+# install hex and rebar
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+# check version
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && env | grep ROS
+RUN mix hex.info
+

--- a/Dockerfile.galactic-ex1.11.4-otp23.3.4
+++ b/Dockerfile.galactic-ex1.11.4-otp23.3.4
@@ -1,0 +1,59 @@
+### FIXME according to branch/tag
+# base image
+FROM hexpm/elixir:1.11.4-erlang-23.3.4-ubuntu-focal-20210325
+# Set Ubuntu Codename
+ENV UBUNTU_CODENAME focal
+# Set ROS_DISTRO environment
+ENV ROS_DISTRO galactic
+
+# force error about debconf
+ENV DEBIAN_FRONTEND noninteractive
+
+# update sources list
+RUN apt-get clean
+RUN apt-get update
+
+# install additonal packages
+RUN apt-get install -y git sudo build-essential
+
+# install AStyle to format C code (NIFs)
+RUN apt-get install -y astyle
+
+### install ROS START
+### https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+
+# Set locale
+RUN apt update && apt -y install locales
+RUN locale-gen en_US en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN export LANG=en_US.UTF-8
+
+# Setup Sources
+RUN apt update && apt install -y curl gnupg2 lsb-release
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Install ROS 2 packages
+RUN apt update
+RUN apt install -y ros-${ROS_DISTRO}-ros-base
+
+# Install ROS 2 packages
+RUN apt install -y python3-colcon-common-extensions
+
+# Setup ROS environment in shell
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> ~/.bashrc
+
+### install ROS END
+
+# cleanup
+RUN apt-get -qy autoremove
+
+# install hex and rebar
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+# check version
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && env | grep ROS
+RUN mix hex.info
+

--- a/Dockerfile.galactic-ex1.12.3-otp24.1.5
+++ b/Dockerfile.galactic-ex1.12.3-otp24.1.5
@@ -1,0 +1,59 @@
+### FIXME according to branch/tag
+# base image
+FROM hexpm/elixir:1.12.3-erlang-24.1.5-ubuntu-focal-20210325
+# Set Ubuntu Codename
+ENV UBUNTU_CODENAME focal
+# Set ROS_DISTRO environment
+ENV ROS_DISTRO galactic
+
+# force error about debconf
+ENV DEBIAN_FRONTEND noninteractive
+
+# update sources list
+RUN apt-get clean
+RUN apt-get update
+
+# install additonal packages
+RUN apt-get install -y git sudo build-essential
+
+# install AStyle to format C code (NIFs)
+RUN apt-get install -y astyle
+
+### install ROS START
+### https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+
+# Set locale
+RUN apt update && apt -y install locales
+RUN locale-gen en_US en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN export LANG=en_US.UTF-8
+
+# Setup Sources
+RUN apt update && apt install -y curl gnupg2 lsb-release
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Install ROS 2 packages
+RUN apt update
+RUN apt install -y ros-${ROS_DISTRO}-ros-base
+
+# Install ROS 2 packages
+RUN apt install -y python3-colcon-common-extensions
+
+# Setup ROS environment in shell
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> ~/.bashrc
+
+### install ROS END
+
+# cleanup
+RUN apt-get -qy autoremove
+
+# install hex and rebar
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+# check version
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && env | grep ROS
+RUN mix hex.info
+

--- a/Dockerfile.galactic-ex1.13.1-otp24.1.7
+++ b/Dockerfile.galactic-ex1.13.1-otp24.1.7
@@ -1,0 +1,59 @@
+### FIXME according to branch/tag
+# base image
+FROM hexpm/elixir:1.13.1-erlang-24.1.7-ubuntu-focal-20210325
+# Set Ubuntu Codename
+ENV UBUNTU_CODENAME focal
+# Set ROS_DISTRO environment
+ENV ROS_DISTRO galactic
+
+# force error about debconf
+ENV DEBIAN_FRONTEND noninteractive
+
+# update sources list
+RUN apt-get clean
+RUN apt-get update
+
+# install additonal packages
+RUN apt-get install -y git sudo build-essential
+
+# install AStyle to format C code (NIFs)
+RUN apt-get install -y astyle
+
+### install ROS START
+### https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+
+# Set locale
+RUN apt update && apt -y install locales
+RUN locale-gen en_US en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN export LANG=en_US.UTF-8
+
+# Setup Sources
+RUN apt update && apt install -y curl gnupg2 lsb-release
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Install ROS 2 packages
+RUN apt update
+RUN apt install -y ros-${ROS_DISTRO}-ros-base
+
+# Install ROS 2 packages
+RUN apt install -y python3-colcon-common-extensions
+
+# Setup ROS environment in shell
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> ~/.bashrc
+
+### install ROS END
+
+# cleanup
+RUN apt-get -qy autoremove
+
+# install hex and rebar
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+# check version
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && env | grep ROS
+RUN mix hex.info
+

--- a/README.md
+++ b/README.md
@@ -11,39 +11,41 @@ $ docker pull rclex/rclex_docker:latest
 $ docker run -it --rm --name rclex rclex/rclex_docker:latest
 ```
 
-## The rule of Docker Tags and Git Branches
+## The rule of Docker Tags
 
 Since Rclex relies heavily on 3 components (ROS 2, Elixir and Erlang/OTP), we decide to give the Tag of Docker image a long name to clarify each version.
 
 - `name`-ex`A.B.C`-otp`X.Y.Z`
-  - `name`: The distribution of ROS 2 (e.g., dashing, foxy)
-  - `A.B.C`: The version of Elixir (e.g., Elixir 1.9.1)
-  - `X.Y.Z`: The version of Erlang (e.g., OTP-22.0.7)
-
-The Tags of Docker image associate with the [Branches of Git/GitHub](https://github.com/rclex/rclex_docker/branches). 
+  - `name`: The distribution of ROS 2 (e.g., foxy)
+  - `A.B.C`: The version of Elixir (e.g., Elixir 1.12.3)
+  - `X.Y.Z`: The version of Erlang (e.g., OTP-24.1.5)
 
 ## Available versions (docker tags)
 
-Here is the list of Tags and links to their respective Branches.
+Here is the list of Tags. They are associated with the ext of each Dockerfile on [GitHub repository](https://github.com/rclex/rclex_docker).
 
 **[latest]** means the `latest` tag and `main` branch.
-_[experimental]_ means that its image has been published but not supported yet for Rclex. Note that README including the  list is surely maintained only on the [main branch](https://github.com/rclex/rclex_docker#the-rule-of-docker-tags-and-git-branches).
-
-### Dashing Diademata
-
-- [dashing-ex1.12.0-otp24.0.1](https://github.com/rclex/rclex_docker/tree/dashing-ex1.12.0-otp24.0.1)
-- [dashing-ex1.11.2-otp23.3.1](https://github.com/rclex/rclex_docker/tree/dashing-ex1.11.2-otp23.3.1)
-  - Note: [dashing-ex1.11.4-otp23.3.1](https://github.com/rclex/rclex_docker/tree/dashing-ex1.11.4-otp23.3.1) does not seem to build the correct version of OTP. So we do not recommend to use it although it was published.  Also check [rclex/rclex#27](https://github.com/rclex/rclex/issues/27).
-- [dashing-ex1.10.4-otp22.3.4](https://github.com/rclex/rclex_docker/tree/dashing-ex1.10.4-otp22.3.4)
-- [dashing-ex1.9.4-otp22.3.4](https://github.com/rclex/rclex_docker/tree/dashing-ex1.9.1-otp22.3.4)
-- [dashing-ex1.9.1-otp22.0.7](https://github.com/rclex/rclex_docker/tree/dashing-ex1.9.1-otp22.0.7)
 
 ### Foxy Fitzroy
 
-- [foxy-ex1.12.0-otp24.0.1](https://github.com/rclex/rclex_docker/tree/foxy-ex1.12.0-otp24.0.1)
-- [foxy-ex1.11.2-otp23.3.1](https://github.com/rclex/rclex_docker/tree/foxy-ex1.11.2-otp23.3.1) **[latest]**
+- foxy-ex1.13.1-otp24.1.7
+- foxy-ex1.12.3-otp24.1.5 **[latest]**
+- foxy-ex1.11.4-otp23.3.4
 
-### Galactic Geochelone
+### Dashing Diademata
 
-- [galactic-ex1.12.0-otp24.0.1](https://github.com/rclex/rclex_docker/tree/galactic-ex1.12.0-otp24.0.1) _[experimental]_
-- [galactic-ex1.11.2-otp23.3.1](https://github.com/rclex/rclex_docker/tree/galactic-ex1.11.2-otp23.3.1) _[experimental]_
+Note: Dashing has already reached EOL, so they are not recommended for use.
+
+- dashing-ex1.12.3-otp24.1.5
+- dashing-ex1.11.4-otp23.3.4
+- dashing-ex1.10.4-otp23.3.4
+- dashing-ex1.9.4-otp22.3.4.18
+
+### _[experimental]_ Galactic Geochelone
+
+Note: Galactic is not suppored yet for Rclex but these images are already published to Docker Hub for the future. 
+
+- galactic-ex1.13.1-otp24.1.7
+- galactic-ex1.12.3-otp24.1.5
+- galactic-ex1.11.4-otp23.3.4
+

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Since Rclex relies heavily on 3 components (ROS 2, Elixir and Erlang/OTP), we de
 
 ## Available versions (docker tags)
 
-Here is the list of Tags. They are associated with the ext of each Dockerfile on [GitHub repository](https://github.com/rclex/rclex_docker).
+Here is the list of Tags (also see [Tags page on Docker Hub](https://hub.docker.com/r/rclex/rclex_docker/tags)). They are associated with the ext of each Dockerfile on [GitHub repository](https://github.com/rclex/rclex_docker).
 
-**[latest]** means the `latest` tag and `main` branch.
+**[latest]** means the `latest` tag and `Dockerfile` (without the ext).
 
 ### Foxy Fitzroy
 

--- a/docker_build_push.sh
+++ b/docker_build_push.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+TAGS=()
+TAGS+=(foxy-ex1.13.1-otp24.1.7 foxy-ex1.12.3-otp24.1.5 foxy-ex1.11.4-otp23.3.4)
+TAGS+=(dashing-ex1.12.3-otp24.1.5 dashing-ex1.11.4-otp23.3.4 dashing-ex1.10.4-otp23.3.4 dashing-ex1.9.4-otp22.3.4.18)
+TAGS+=(galactic-ex1.13.1-otp24.1.7 galactic-ex1.12.3-otp24.1.5 galactic-ex1.11.4-otp23.3.4)
+
+for tag in ${TAGS[@]};
+do
+  echo ${tag}
+  ls Dockerfile.${tag} > /dev/null
+  result=$?
+  if [ $result -eq 0 ];
+  then
+    echo "INFO: building ${tag} as target tags os Docker image"
+    docker build . -f Dockerfile.${tag} -t rclex/rclex_docker:${tag}
+    echo ${tag}
+    docker run --rm rclex/rclex_docker:${tag} bash -c 'echo ${ROS_DISTRO}'
+    docker run --rm rclex/rclex_docker:${tag} bash -c 'mix hex.info'
+    sleep 3
+    docker push rclex/rclex_docker:${tag}
+  else
+    echo "ERROR: Docker tag ${tag} does not exist in rclex/rclex_docker"
+    exit $result
+    fi
+done


### PR DESCRIPTION
Since `erlang-solutions_2.0_all.deb` package, that has been employed for this repository, sometimes exclude the versions of Elixir required for testing Rclex. Since we are planning to automate Docker build & push in the future, this mannar will be a cause to achieve this. Therefore, we change the building policy:
- before: employ `ros` from OSRF as base image, and then install Elixir/Erlang environment
- after : employ `elixir` from Hexpm team as base image, and then install ROS environment

This change also contribute to reduce the size of image, from 1.63 GB to 1.02 GB (in `foxy-ex1.12.3-otp24.1.5`).

---

And also, we prepare Dockerfile for each Tags on the main branch.
Since automate Build for the integration of GitHub and Docker Hub has been expired for free account, the previous method to associate Docker tags and Git branches is no longer useful. So we change the maintainance policy of tags and each Dockerfile for each image.

---

FYI: The combination of Elixir/Erlang follows the policy from Nerves Project 😄 
https://github.com/nerves-project/nerves/blob/main/.circleci/config.yml