### PR TITLE
add `iron-ex1.15.5-otp26.0.2` image

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,16 @@ Here is the list of Tags (also see [Tags page on Docker Hub](https://hub.docker.
 **[latest]** means the `latest` tag associated with [the recommended environment for Rclex](https://github.com/rclex/rclex#recommended-environment).
 Only this tag provides multi-platform, `linux/amd64` and `linux/arm64`.
 
-- Iron Irwini
+- Iron Irwini (_STS until Nov 2024_)
   - iron-ex1.15.5-otp26.0.2
-- Humble Hawksbill
+- Humble Hawksbill (**LTS rosdistro until May 2027**)
   - humble-ex1.15.5-otp26.0.2 **[latest]**
   - humble-ex1.14.5-otp25.3.2.5
   - humble-ex1.13.4-otp25.0.3
-- Galactic Geochelone
+- Galactic Geochelone (_EOL!_)
   - galactic-ex1.15.5-otp26.0.2
-- Foxy Fitzroy
+- Foxy Fitzroy (_EOL!_)
   - foxy-ex1.15.5-otp26.0.2
-  - foxy-ex1.14.5-otp25.3.2.5
-  - foxy-ex1.13.4-otp25.0.3
 
 We highly recommend using Humble version because the previous ROS 2 distributions have already reached EOL.
 In particular, we have decided to stop supporting for Dashing due to compatibility with Rclex code.
@@ -55,7 +53,9 @@ The following versions were used in the past and are still available on Docker H
   - galactic-ex1.12.3-otp24.1.5
   - galactic-ex1.11.4-otp23.3.4
 - Foxy Fitzroy
+  - foxy-ex1.14.5-otp25.3.2.5
   - foxy-ex1.14.0-otp25.0.4
+  - foxy-ex1.13.4-otp25.0.3
   - foxy-ex1.13.1-otp24.1.7
   - foxy-ex1.12.3-otp24.1.5
   - foxy-ex1.11.4-otp23.3.4

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ Here is the list of Tags (also see [Tags page on Docker Hub](https://hub.docker.
 **[latest]** means the `latest` tag associated with [the recommended environment for Rclex](https://github.com/rclex/rclex#recommended-environment).
 Only this tag provides multi-platform, `linux/amd64` and `linux/arm64`.
 
-- Iron Irwini (_STS until Nov 2024_)
-  - iron-ex1.15.5-otp26.0.2
 - Humble Hawksbill (**LTS rosdistro until May 2027**)
   - humble-ex1.15.5-otp26.0.2 **[latest]**
   - humble-ex1.14.5-otp25.3.2.5
@@ -40,6 +38,13 @@ Only this tag provides multi-platform, `linux/amd64` and `linux/arm64`.
 
 We highly recommend using Humble version because the previous ROS 2 distributions have already reached EOL.
 In particular, we have decided to stop supporting for Dashing due to compatibility with Rclex code.
+
+### Experimental versions
+
+The following versions are not supported yet and used as CI targets for Rclex, but these images are already published to Docker Hub for the future.
+
+- Iron Irwini (_STS until Nov 2024_)
+  - iron-ex1.15.5-otp26.0.2
 
 ### Deprecated versions
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Here is the list of Tags (also see [Tags page on Docker Hub](https://hub.docker.
 **[latest]** means the `latest` tag associated with [the recommended environment for Rclex](https://github.com/rclex/rclex#recommended-environment).
 Only this tag provides multi-platform, `linux/amd64` and `linux/arm64`.
 
+- Iron Irwini
+  - iron-ex1.15.5-otp26.0.2
 - Humble Hawksbill
   - humble-ex1.15.5-otp26.0.2 **[latest]**
   - humble-ex1.14.5-otp25.3.2.5

--- a/lib/mix/tasks/rclex_docker.ex
+++ b/lib/mix/tasks/rclex_docker.ex
@@ -32,9 +32,9 @@ defmodule Mix.Tasks.RclexDocker do
       # {"hexpm/elixir:1.9.4-erlang-22.3.4.18-ubuntu-bionic-20210325", "dashing"},
       ### Foxy
       {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-focal-20230126", "foxy"},
-      {"hexpm/elixir:1.14.5-erlang-25.3.2.5-ubuntu-focal-20230126", "foxy"},
+      # {"hexpm/elixir:1.14.5-erlang-25.3.2.5-ubuntu-focal-20230126", "foxy"},
       # {"hexpm/elixir:1.14.0-erlang-25.0.4-ubuntu-focal-20211006", "foxy"},
-      {"hexpm/elixir:1.13.4-erlang-25.0.3-ubuntu-focal-20211006", "foxy"},
+      # {"hexpm/elixir:1.13.4-erlang-25.0.3-ubuntu-focal-20211006", "foxy"},
       # {"hexpm/elixir:1.13.1-erlang-24.1.7-ubuntu-focal-20210325", "foxy"},
       # {"hexpm/elixir:1.12.3-erlang-24.1.5-ubuntu-focal-20210325", "foxy"},
       # {"hexpm/elixir:1.11.4-erlang-23.3.4-ubuntu-focal-20210325", "foxy"},

--- a/lib/mix/tasks/rclex_docker.ex
+++ b/lib/mix/tasks/rclex_docker.ex
@@ -47,8 +47,10 @@ defmodule Mix.Tasks.RclexDocker do
       ### Humble
       {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126", "humble"},
       {"hexpm/elixir:1.14.5-erlang-25.3.2.5-ubuntu-jammy-20230126", "humble"},
-      {"hexpm/elixir:1.13.4-erlang-25.0.3-ubuntu-jammy-20220428", "humble"}
+      {"hexpm/elixir:1.13.4-erlang-25.0.3-ubuntu-jammy-20220428", "humble"},
       # {"hexpm/elixir:1.13.4-erlang-24.3.4.2-ubuntu-jammy-20220428", "humble"}
+      ### Iron
+      {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126", "iron"}
     ]
   end
 


### PR DESCRIPTION
docker build & push は実施済みです．
GitHub Actions 時間の削減のために foxy-ex13,14 も除外することにしました．