### PR TITLE
refactor Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ### FIXME according to the target version
 # base image, ARG is overridable by --build-arg
-ARG BASE_IMAGE=hexpm/elixir:1.13.4-erlang-25.0.3-ubuntu-focal-20211006
+ARG BASE_IMAGE=hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126
 FROM $BASE_IMAGE
 # Set Ubuntu Codename ENV, ARG is overridable by --build-arg
 ARG UBUNTU_CODENAME
-ENV UBUNTU_CODENAME=${UBUNTU_CODENAME:-focal}
+ENV UBUNTU_CODENAME=${UBUNTU_CODENAME:-jammy}
 # Set ROS_DISTRO ENV, ARG is overridable by --build-arg
 ARG ROS_DISTRO
-ENV ROS_DISTRO=${ROS_DISTRO:-foxy}
+ENV ROS_DISTRO=${ROS_DISTRO:-humble}
 
 # force error about debconf
 ENV DEBIAN_FRONTEND noninteractive
@@ -23,7 +23,7 @@ RUN apt-get clean && \
   && rm -rf /var/lib/apt/lists/*
 
 ### install ROS START
-### https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+### https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html
 
 # Set locale
 RUN apt-get update && apt-get -y install locales && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,74 +1,83 @@
-### FIXME according to the target version
-# base image, ARG is overridable by --build-arg
+# Setup the target version
+## base image, ARG is overridable by --build-arg
 ARG BASE_IMAGE=hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126
 FROM $BASE_IMAGE
-# Set Ubuntu Codename ENV, ARG is overridable by --build-arg
+## Set Ubuntu version by Codename, ARG is overridable by --build-arg
 ARG UBUNTU_CODENAME
 ENV UBUNTU_CODENAME=${UBUNTU_CODENAME:-jammy}
-# Set ROS_DISTRO ENV, ARG is overridable by --build-arg
+## Set ROS 2 distribution, ARG is overridable by --build-arg
 ARG ROS_DISTRO
 ENV ROS_DISTRO=${ROS_DISTRO:-humble}
 
-# force error about debconf
+# Force error about debconf
 ENV DEBIAN_FRONTEND noninteractive
 
-# update sources list
+# Install for rclex_docker
 ## inotify-tools: for mix test.watch
 ## astyle: to format C code in NIFs
-RUN apt-get clean && \
-  apt-get update && \
-  apt-get install -y git sudo build-essential \
+RUN apt-get update && apt-get install -y \
+  git sudo build-essential \
   inotify-tools \
   astyle \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-### install ROS START
-### https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html
+# Install ROS START
+## refer to https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html
 
-# Set locale
-RUN apt-get update && apt-get -y install locales && \
-  locale-gen en_US en_US.UTF-8 && \
-  update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 && \
-  export LANG=en_US.UTF-8 \
+## Set locale
+RUN apt-get update && apt-get -y install \
+  locales \
+  && locale-gen en_US en_US.UTF-8 \
+  && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+  && export LANG=en_US.UTF-8 \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# Setup Sources
-RUN apt-get update && apt-get install -y curl gnupg2 lsb-release \
+## Setup Sources
+RUN apt-get update && apt-get install -y \
+  software-properties-common \
+  curl \
+  && sudo add-apt-repository universe \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
-# Upgrade before installing ROS 2 packages
-# WHY: refer to "Warning" in https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html#install-ros-2-packages
+## Upgrade before installing ROS 2 packages
+## WHY: refer to "Warning" in https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html#install-ros-2-packages
 RUN apt-get update \
-  && apt-get upgrade \
+  && apt-get -y upgrade \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# Install ROS 2 packages
-RUN apt-get update && \
-  apt-get install -y ros-${ROS_DISTRO}-ros-base \
+## Install ROS 2 packages
+RUN apt-get update && apt-get install -y \
+  ros-${ROS_DISTRO}-ros-base \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# Install colcon-core
-RUN apt-get update && \
-  apt-get install -y python3-colcon-common-extensions \
+## Install colcon-core
+RUN apt-get update && apt-get install -y \
+  python3-colcon-common-extensions \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# Setup ROS environment in shell
+## Setup ROS environment in shell
 RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.sh' >> ~/.bashrc
 
-### install ROS END
+# Install ROS END
 
 # cleanup
 RUN apt-get -qy autoremove
 
-# install hex and rebar
+# Install hex and rebar
 RUN mix local.hex --force && \
   mix local.rebar --force
 
-# check version
+# Check version
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && env | grep ROS && \
   mix hex.info
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,13 @@ RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o
 
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
+# Upgrade before installing ROS 2 packages
+# WHY: refer to "Warning" in https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html#install-ros-2-packages
+RUN apt-get update \
+  && apt-get upgrade \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install ROS 2 packages
 RUN apt-get update && \
   apt-get install -y ros-${ROS_DISTRO}-ros-base \


### PR DESCRIPTION
This PR mainly contributes to refactoring Dockerfile, and adjusting the official ROS 2 installation steps.
One big change is to add `apt upgrade` before installing the ROS 2 package because it is recommended as "Warning" label in https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html#install-ros-2-packages 