### PR TITLE
change latest to humble-ex1.15.7-otp26.2.2, add elixir v1.16, and sort out older tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Setup the target version
 ## base image, ARG is overridable by --build-arg
-ARG BASE_IMAGE=hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126
+ARG BASE_IMAGE=hexpm/elixir:1.15.7-erlang-26.2.3-ubuntu-jammy-20240125
 FROM $BASE_IMAGE
 ## Set Ubuntu version by Codename, ARG is overridable by --build-arg
 ARG UBUNTU_CODENAME

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2021- [Rclex Dev Team](https://github.com/rclex/)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository maintains the Dockerfile for the trial and tests of [Rclex](http
 
 https://hub.docker.com/r/rclex/rclex_docker
 
-You can use the Docker image like the follow.
+You can use the Docker image like the following.
 
 ```
 $ docker pull rclex/rclex_docker:latest
@@ -13,7 +13,7 @@ $ docker run -it --rm --name rclex rclex/rclex_docker:latest
 
 ## The rule of Docker Tags
 
-Since Rclex relies heavily on 3 components (ROS 2, Elixir and Erlang/OTP), we decide to give the Tag of Docker image a long name to clarify each version.
+Since Rclex relies heavily on 3 components (ROS 2, Elixir and Erlang/OTP), we decided to give the Tag of Docker image a long name to clarify each version.
 
 - `name`-ex`A.B.C`-otp`X.Y.Z`
   - `name`: The distribution of ROS 2 (e.g., humble)
@@ -22,10 +22,11 @@ Since Rclex relies heavily on 3 components (ROS 2, Elixir and Erlang/OTP), we de
 
 ## Available versions (docker tags)
 
-Here is the list of Tags (also see [Tags page on Docker Hub](https://hub.docker.com/r/rclex/rclex_docker/tags)). They are associated with the ext of each Dockerfile on [GitHub repository](https://github.com/rclex/rclex_docker).
+Here is the list of Tags (also see [Tags page on Docker Hub](https://hub.docker.com/r/rclex/rclex_docker/tags)) as the CI targets for Rclex.
+They are associated with the ext of each Dockerfile on [GitHub repository](https://github.com/rclex/rclex_docker).
 
 **[latest]** means the `latest` tag associated with [the recommended environment for Rclex](https://github.com/rclex/rclex#recommended-environment).
-Only this tag provides multi-platform, `linux/amd64` and `linux/arm64`.
+Only this tag (including past) provides multi-platform, `linux/amd64` and `linux/arm64`.
 
 - Humble Hawksbill (**LTS rosdistro until May 2027**)
   - humble-ex1.15.5-otp26.0.2 **[latest]**
@@ -37,11 +38,11 @@ Only this tag provides multi-platform, `linux/amd64` and `linux/arm64`.
   - foxy-ex1.15.5-otp26.0.2
 
 We highly recommend using Humble version because the previous ROS 2 distributions have already reached EOL.
-In particular, we have decided to stop supporting for Dashing due to compatibility with Rclex code.
+In particular, we have decided to stop supporting Dashing due to compatibility with Rclex code.
 
 ### Experimental versions
 
-The following versions are not supported yet and used as CI targets for Rclex, but these images are already published to Docker Hub for the future.
+The following versions are not supported yet and are used as CI targets for Rclex, but these images have been published to Docker Hub for the future.
 
 - Iron Irwini (_STS until Nov 2024_)
   - iron-ex1.15.5-otp26.0.2

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ They are associated with the ext of each Dockerfile on [GitHub repository](https
 Only this tag (including past) provides multi-platform, `linux/amd64` and `linux/arm64`.
 
 - Humble Hawksbill (**LTS rosdistro until May 2027**)
-  - humble-ex1.16.2-otp26.2.3
-  - humble-ex1.15.7-otp26.2.3 **[latest]**
+  - humble-ex1.16.2-otp26.2.2
+  - humble-ex1.15.7-otp26.2.2 **[latest]**
   - humble-ex1.14.5-otp25.3.2.5
 - Foxy Fitzroy (_EOL!_)
   - foxy-ex1.15.5-otp26.0.2

--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@ They are associated with the ext of each Dockerfile on [GitHub repository](https
 Only this tag (including past) provides multi-platform, `linux/amd64` and `linux/arm64`.
 
 - Humble Hawksbill (**LTS rosdistro until May 2027**)
-  - humble-ex1.15.5-otp26.0.2 **[latest]**
+  - humble-ex1.16.2-otp26.2.3
+  - humble-ex1.15.7-otp26.2.3 **[latest]**
   - humble-ex1.14.5-otp25.3.2.5
-  - humble-ex1.13.4-otp25.0.3
-- Galactic Geochelone (_EOL!_)
-  - galactic-ex1.15.5-otp26.0.2
 - Foxy Fitzroy (_EOL!_)
   - foxy-ex1.15.5-otp26.0.2
 
@@ -52,20 +50,23 @@ The following versions are not supported yet and are used as CI targets for Rcle
 The following versions were used in the past and are still available on Docker Hub, but are no longer used for the operation test of Rclex.
 
 - Humble Hawksbill
+  - humble-ex1.15.5-otp26.0.2 (past latest)
+  - humble-ex1.13.4-otp25.0.3
   - humble-ex1.13.4-otp24.3.4.2
-- Galactic Geochelone
+- Galactic Geochelone (_EOL!_)
+  - galactic-ex1.15.5-otp26.0.2
   - galactic-ex1.13.4-otp25.0.3
   - galactic-ex1.13.1-otp24.1.7
   - galactic-ex1.12.3-otp24.1.5
   - galactic-ex1.11.4-otp23.3.4
-- Foxy Fitzroy
+- Foxy Fitzroy (_EOL!_)
   - foxy-ex1.14.5-otp25.3.2.5
   - foxy-ex1.14.0-otp25.0.4
   - foxy-ex1.13.4-otp25.0.3
   - foxy-ex1.13.1-otp24.1.7
   - foxy-ex1.12.3-otp24.1.5
   - foxy-ex1.11.4-otp23.3.4
-- Dashing Diademata
+- Dashing Diademata (_EOL!_)
   - dashing-ex1.12.3-otp24.1.5
   - dashing-ex1.11.4-otp23.3.4
   - dashing-ex1.10.4-otp23.3.4

--- a/lib/mix/tasks/rclex_docker.ex
+++ b/lib/mix/tasks/rclex_docker.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.RclexDocker do
   end
 
   def latest_target_tuple() do
-    {"hexpm/elixir:1.15.7-erlang-26.2.3-ubuntu-jammy-20240125", "humble"}
+    {"hexpm/elixir:1.15.7-erlang-26.2.2-ubuntu-jammy-20240125", "humble"}
   end
 
   def list_target_tuples() do
@@ -45,8 +45,8 @@ defmodule Mix.Tasks.RclexDocker do
       # {"hexpm/elixir:1.12.3-erlang-24.1.5-ubuntu-focal-20210325", "galactic"},
       # {"hexpm/elixir:1.11.4-erlang-23.3.4-ubuntu-focal-20210325", "galactic"},
       ### Humble
-      {"hexpm/elixir:1.16.2-erlang-26.2.3-ubuntu-jammy-20240125", "humble"},
-      {"hexpm/elixir:1.15.7-erlang-26.2.3-ubuntu-jammy-20240125", "humble"},
+      {"hexpm/elixir:1.16.2-erlang-26.2.2-ubuntu-jammy-20240125", "humble"},
+      {"hexpm/elixir:1.15.7-erlang-26.2.2-ubuntu-jammy-20240125", "humble"},
       # {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126", "humble"},
       {"hexpm/elixir:1.14.5-erlang-25.3.2.5-ubuntu-jammy-20230126", "humble"},
       # {"hexpm/elixir:1.13.4-erlang-25.0.3-ubuntu-jammy-20220428", "humble"},

--- a/lib/mix/tasks/rclex_docker.ex
+++ b/lib/mix/tasks/rclex_docker.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.RclexDocker do
   end
 
   def latest_target_tuple() do
-    {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126", "humble"}
+    {"hexpm/elixir:1.15.7-erlang-26.2.3-ubuntu-jammy-20240125", "humble"}
   end
 
   def list_target_tuples() do
@@ -39,15 +39,17 @@ defmodule Mix.Tasks.RclexDocker do
       # {"hexpm/elixir:1.12.3-erlang-24.1.5-ubuntu-focal-20210325", "foxy"},
       # {"hexpm/elixir:1.11.4-erlang-23.3.4-ubuntu-focal-20210325", "foxy"},
       ### Galactic
-      {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-focal-20230126", "galactic"},
+      # {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-focal-20230126", "galactic"},
       # {"hexpm/elixir:1.13.4-erlang-25.0.3-ubuntu-focal-20211006", "galactic"},
       # {"hexpm/elixir:1.13.1-erlang-24.1.7-ubuntu-focal-20210325", "galactic"},
       # {"hexpm/elixir:1.12.3-erlang-24.1.5-ubuntu-focal-20210325", "galactic"},
       # {"hexpm/elixir:1.11.4-erlang-23.3.4-ubuntu-focal-20210325", "galactic"},
       ### Humble
-      {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126", "humble"},
+      {"hexpm/elixir:1.16.2-erlang-26.2.3-ubuntu-jammy-20240125", "humble"},
+      {"hexpm/elixir:1.15.7-erlang-26.2.3-ubuntu-jammy-20240125", "humble"},
+      # {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126", "humble"},
       {"hexpm/elixir:1.14.5-erlang-25.3.2.5-ubuntu-jammy-20230126", "humble"},
-      {"hexpm/elixir:1.13.4-erlang-25.0.3-ubuntu-jammy-20220428", "humble"},
+      # {"hexpm/elixir:1.13.4-erlang-25.0.3-ubuntu-jammy-20220428", "humble"},
       # {"hexpm/elixir:1.13.4-erlang-24.3.4.2-ubuntu-jammy-20220428", "humble"}
       ### Iron
       {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126", "iron"}


### PR DESCRIPTION
This PR changes the `latest` tag that contains the recommended tool versions for Rclex to `humble-ex1.15.7-otp26.2.2`.
Also, `humble-ex1.16.2-otp26.2.2` is added, and some older tags are sorted out.

- Humble Hawksbill (**LTS rosdistro until May 2027**)
  - humble-ex1.16.2-otp26.2.2
  - humble-ex1.15.7-otp26.2.2 **[latest]**
  - humble-ex1.14.5-otp25.3.2.5
- Foxy Fitzroy (_EOL!_)
  - foxy-ex1.15.5-otp26.0.2
- [experimental] Iron Irwini (_STS until Nov 2024_)
  - iron-ex1.15.5-otp26.0.2

I will merge this PR after pushing these new tags, and confirming these operations with the Rclex CI test.

---

Note that the initial of this PR used OTP 26.2.3, but I found the issue on arm64, so I decided to downgrade to 26.2.2 for now (see [detail](https://github.com/rclex/rclex_docker/pull/17#issuecomment-2017233120))