### PR TITLE
Reorganize supported versions to follow the current situation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Setup the target version
 ## base image, ARG is overridable by --build-arg
-ARG BASE_IMAGE=hexpm/elixir:1.15.7-erlang-26.2.3-ubuntu-jammy-20240125
+ARG BASE_IMAGE=hexpm/elixir:1.17.3-erlang-27.2.4-ubuntu-jammy-20250126
 FROM $BASE_IMAGE
 ## Set Ubuntu version by Codename, ARG is overridable by --build-arg
 ARG UBUNTU_CODENAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG UBUNTU_CODENAME
 ENV UBUNTU_CODENAME=${UBUNTU_CODENAME:-jammy}
 ## Set ROS 2 distribution, ARG is overridable by --build-arg
 ARG ROS_DISTRO
-ENV ROS_DISTRO=${ROS_DISTRO:-jazzy}
+ENV ROS_DISTRO=${ROS_DISTRO:-humble}
 
 # Force error about debconf
 ENV DEBIAN_FRONTEND=noninteractive
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Install ROS START
-## refer to https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html
+## refer to https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html
 
 ## Set locale
 RUN apt-get update && apt-get -y install \
@@ -47,7 +47,7 @@ RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
 ## Upgrade before installing ROS 2 packages
-## WHY: refer to "Warning" in https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html#install-ros-2-packages
+## WHY: refer to "Warning" in https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html#install-ros-2-packages
 RUN apt-get update \
   && apt-get -y upgrade \
   && apt-get clean \

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ They are associated with the ext of each Dockerfile on [GitHub repository](https
 Only this tag (including past) provides multi-platform, `linux/amd64` and `linux/arm64`.
 
 - Jazzy Jalisco (**LTS rosdistro until May 2029**)
-  - jazzy-ex1.17.3-otp27.2
+  - jazzy-ex1.18.2-otp27.2.4
+  - jazzy-ex1.17.3-otp27.2.4
+  - jazzy-ex1.16.3-otp26.2.5
 - Humble Hawksbill (**LTS rosdistro until May 2027**)
-  - humble-ex1.16.2-otp26.2.2
-  - humble-ex1.15.7-otp26.2.2 **[latest]**
-  - humble-ex1.14.5-otp25.3.2.5
-- Foxy Fitzroy (_EOL!_)
-  - foxy-ex1.15.5-otp26.0.2
+  - humble-ex1.18.2-otp27.2.4
+  - humble-ex1.17.3-otp27.2.4 **[latest]**
+  - humble-ex1.16.3-otp26.2.5
 
 We highly recommend using Humble version because the previous ROS 2 distributions have already reached EOL.
 In particular, we have decided to stop supporting Dashing due to compatibility with Rclex code.
@@ -44,14 +44,20 @@ In particular, we have decided to stop supporting Dashing due to compatibility w
 
 The following versions are not supported yet and are used as CI targets for Rclex, but these images have been published to Docker Hub for the future.
 
-- Iron Irwini (_STS until Nov 2024_)
-  - iron-ex1.15.5-otp26.0.2
+- None of this now
 
 ### Deprecated versions
 
 The following versions were used in the past and are still available on Docker Hub, but are no longer used for the operation test of Rclex.
 
+- Jazzy Jalisco (**LTS rosdistro until May 2029**)
+  - jazzy-ex1.17.3-otp27.2
+- Iron Irwini (_EOL!_)
+  - iron-ex1.15.5-otp26.0.2
 - Humble Hawksbill
+  - humble-ex1.16.2-otp26.2.2
+  - humble-ex1.15.7-otp26.2.2 (past latest)
+  - humble-ex1.14.5-otp25.3.2.5
   - humble-ex1.15.5-otp26.0.2 (past latest)
   - humble-ex1.13.4-otp25.0.3
   - humble-ex1.13.4-otp24.3.4.2
@@ -62,6 +68,7 @@ The following versions were used in the past and are still available on Docker H
   - galactic-ex1.12.3-otp24.1.5
   - galactic-ex1.11.4-otp23.3.4
 - Foxy Fitzroy (_EOL!_)
+  - foxy-ex1.15.5-otp26.0.2
   - foxy-ex1.14.5-otp25.3.2.5
   - foxy-ex1.14.0-otp25.0.4
   - foxy-ex1.13.4-otp25.0.3

--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ Only this tag (including past) provides multi-platform, `linux/amd64` and `linux
 We highly recommend using Humble version because the previous ROS 2 distributions have already reached EOL.
 In particular, we have decided to stop supporting Dashing due to compatibility with Rclex code.
 
+### Policy for versions maintenance
+
+First of all, please understand that we do not maintain this repository and Rclex at all times due to our limited development resource,,,
+
+For Elixir, the version one earlier than the latest is considered as the "latest" version of this repository and Rclex.
+The subminor is assigned to the latest (last) version.
+Therefore, when 1.18 is already released, this repository's "latest" Elixir is 1.17.3.  
+For Erlang/OTP, we select the corresponding one.
+
+The Docker images are maintained to support previous and later versions from "latest".
+For the previous version, the OTP version is lowered by one.
+For the later version, we do not always keep up with the latest Elixir releases.
+
+It's hard to decide which LTS ROS distribution should be the "latest" one,,, 
+We generally choose the most popular ones in the community at the time.
+However, please feel free to ask us if you want to use a newer distribution with Rclex for your project development.
+We do not actively support STS ROS Distribution.
+If Rclex works with only minor changes, we will support them, but if it is too much work, we will skip it.
+
 ### Experimental versions
 
 The following versions are not supported yet and are used as CI targets for Rclex, but these images have been published to Docker Hub for the future.

--- a/lib/mix/tasks/rclex_docker.ex
+++ b/lib/mix/tasks/rclex_docker.ex
@@ -20,18 +20,27 @@ defmodule Mix.Tasks.RclexDocker do
   end
 
   def latest_target_tuple() do
-    {"hexpm/elixir:1.15.7-erlang-26.2.2-ubuntu-jammy-20240125", "humble"}
+    {"hexpm/elixir:1.17.3-erlang-27.2.4-ubuntu-jammy-20250126", "humble"}
   end
 
   def list_target_tuples() do
     [
+      ### Humble
+      {"hexpm/elixir:1.18.2-erlang-27.2.4-ubuntu-jammy-20250126", "humble"},
+      {"hexpm/elixir:1.17.3-erlang-27.2.4-ubuntu-jammy-20250126", "humble"},
+      {"hexpm/elixir:1.16.3-erlang-26.2.5-ubuntu-jammy-20240530", "humble"},
+      ### Jazzy
+      {"hexpm/elixir:1.18.2-erlang-27.2.4-ubuntu-noble-20250127", "jazzy"},
+      {"hexpm/elixir:1.17.3-erlang-27.2.4-ubuntu-noble-20250127", "jazzy"},
+      {"hexpm/elixir:1.16.3-erlang-26.2.5-ubuntu-noble-20240530", "jazzy"}
+      ##### The below are already deprecated versions
       ### Dashing
       # {"hexpm/elixir:1.12.3-erlang-24.1.5-ubuntu-bionic-20210325", "dashing"},
       # {"hexpm/elixir:1.11.4-erlang-23.3.4-ubuntu-bionic-20210325", "dashing"},
       # {"hexpm/elixir:1.10.4-erlang-23.3.4-ubuntu-bionic-20210325", "dashing"},
       # {"hexpm/elixir:1.9.4-erlang-22.3.4.18-ubuntu-bionic-20210325", "dashing"},
       ### Foxy
-      {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-focal-20230126", "foxy"},
+      # {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-focal-20230126", "foxy"},
       # {"hexpm/elixir:1.14.5-erlang-25.3.2.5-ubuntu-focal-20230126", "foxy"},
       # {"hexpm/elixir:1.14.0-erlang-25.0.4-ubuntu-focal-20211006", "foxy"},
       # {"hexpm/elixir:1.13.4-erlang-25.0.3-ubuntu-focal-20211006", "foxy"},
@@ -45,16 +54,14 @@ defmodule Mix.Tasks.RclexDocker do
       # {"hexpm/elixir:1.12.3-erlang-24.1.5-ubuntu-focal-20210325", "galactic"},
       # {"hexpm/elixir:1.11.4-erlang-23.3.4-ubuntu-focal-20210325", "galactic"},
       ### Humble
-      {"hexpm/elixir:1.16.2-erlang-26.2.2-ubuntu-jammy-20240125", "humble"},
-      {"hexpm/elixir:1.15.7-erlang-26.2.2-ubuntu-jammy-20240125", "humble"},
+      # {"hexpm/elixir:1.16.2-erlang-26.2.2-ubuntu-jammy-20240125", "humble"},
+      # {"hexpm/elixir:1.15.7-erlang-26.2.2-ubuntu-jammy-20240125", "humble"},
       # {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126", "humble"},
-      {"hexpm/elixir:1.14.5-erlang-25.3.2.5-ubuntu-jammy-20230126", "humble"},
+      # {"hexpm/elixir:1.14.5-erlang-25.3.2.5-ubuntu-jammy-20230126", "humble"},
       # {"hexpm/elixir:1.13.4-erlang-25.0.3-ubuntu-jammy-20220428", "humble"},
       # {"hexpm/elixir:1.13.4-erlang-24.3.4.2-ubuntu-jammy-20220428", "humble"}
       ### Iron
-      {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126", "iron"},
-      ### Jazzy
-      {"hexpm/elixir:1.17.3-erlang-27.2-ubuntu-noble-20241118.1", "jazzy"}
+      # {"hexpm/elixir:1.15.5-erlang-26.0.2-ubuntu-jammy-20230126", "iron"},
     ]
   end
 


### PR DESCRIPTION
I decided to organize the versions to be supported according to the latest status.
I also tried to describe the policy for versions to be maintained.

@pojiro I would be glad to know your opinion and review.

Note that I have not pushed these changed versions to Docker Hub yet.
(there seems to be a network problem in my environment;;(